### PR TITLE
Allow passing database values using environment variables

### DIFF
--- a/result/server.js
+++ b/result/server.js
@@ -27,10 +27,12 @@ io.sockets.on('connection', function (socket) {
   });
 });
 
+const db_url = process.env.DB_URL || 'postgres://postgres@db/postgres'
+
 async.retry(
   {times: 1000, interval: 1000},
   function(callback) {
-    pg.connect('postgres://postgres@db/postgres', function(err, client, done) {
+    pg.connect(db_url, function(err, client, done) {
       if (err) {
         console.error("Waiting for db");
       }

--- a/vote/app.py
+++ b/vote/app.py
@@ -17,7 +17,8 @@ app = Flask(__name__)
 
 def get_redis():
     if not hasattr(g, 'redis'):
-        g.redis = Redis(host="redis", db=0, socket_timeout=5)
+        redis_url = os.getenv('REDIS_URL', 'redis://redis/0')
+        g.redis = Redis.from_url(redis_url, socket_timeout=5)
     return g.redis
 
 @app.route("/", methods=['POST','GET'])

--- a/worker/src/main/java/worker/Worker.java
+++ b/worker/src/main/java/worker/Worker.java
@@ -10,8 +10,8 @@ import java.lang.management.*;
 class Worker {
   public static void main(String[] args) throws Exception {
     try {
-      Jedis redis = connectToRedis("redis");
-      Connection dbConn = connectToDB("db");
+      Jedis redis = connectToRedis();
+      Connection dbConn = connectToDB();
       MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
       Metric mBean = new Metric();
       ObjectName name = new ObjectName("worker:type=Metric");
@@ -56,7 +56,12 @@ class Worker {
     }
   }
 
-  static Jedis connectToRedis(String host) {
+  static Jedis connectToRedis() {
+    String host = System.getenv("REDIS_HOST");
+    if (host == null) {
+      host = "redis";
+    }
+
     Jedis conn = new Jedis(host);
 
     while (true) {
@@ -73,13 +78,15 @@ class Worker {
     return conn;
   }
 
-  static Connection connectToDB(String host) throws SQLException {
+  static Connection connectToDB() throws SQLException {
     Connection conn = null;
 
     try {
-
       Class.forName("org.postgresql.Driver");
-      String url = "jdbc:postgresql://" + host + "/postgres";
+      String url = System.getenv("DB_URL");
+      if (url == null) {
+        url = "jdbc:postgresql://db/postgres";
+      }
 
       while (conn == null) {
         try {


### PR DESCRIPTION
This patch adds feature for passing DB_URL and REDIS_URL / REDIS_HOST to example-voting-app. It also keeps a fallback when no environment variables are present.

Thanks!